### PR TITLE
Fix trailing space in setup find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="google_ads_mcp_server",
     version="0.1.0",
-    packages=find_packages(include=['google_ads_mcp_server', 'google_ads_mcp_server.* ']),
+    packages=find_packages(include=['google_ads_mcp_server', 'google_ads_mcp_server.*']),
     # Add other dependencies here if needed for the package itself
     # install_requires=[], 
     # Tests require additional packages, but they aren't needed for the package itself


### PR DESCRIPTION
## Summary
- fix packaging by removing stray whitespace from `setup.py`

## Testing
- `pre-commit run --files setup.py` *(fails: pre-commit not installed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google_ads_mcp_server')*

------
https://chatgpt.com/codex/tasks/task_e_6842d258ccc0832fafdcdd93877f4d5a