### PR TITLE
Update security docs

### DIFF
--- a/docs/SECURITY_INSTRUCTIONS.md
+++ b/docs/SECURITY_INSTRUCTIONS.md
@@ -4,16 +4,14 @@ This document provides instructions for completing the secret detection and remo
 
 ## 1. Delete .env Files
 
-Since we cannot delete these files through the API, please manually delete the following .env files that contain real credentials:
+Since we cannot delete these files through the API, please manually delete the `.env` file that contains real credentials:
 
 - `/.env`
-- `/google-mcp-server/.env`
 
 You can do this with:
 
 ```bash
 rm .env
-rm google-mcp-server/.env
 ```
 
 ## 2. Amend the Current Commit
@@ -33,7 +31,7 @@ git push -f origin main
 
 ## 3. Rotate Your Credentials
 
-Since your credentials were exposed in the Git history and in the nova-authentication-plan.md file, you should:
+Since your credentials were exposed in the Git history, you should:
 
 1. Go to the Google Cloud Console
 2. Create new OAuth 2.0 credentials
@@ -90,11 +88,6 @@ This document provides instructions for maintaining a secure development environ
    # Edit .env with your real credentials
    ```
 
-2. For the google-mcp-server subdirectory:
-   ```bash
-   cp google-mcp-server/.env.example google-mcp-server/.env
-   # Edit with your real credentials
-   ```
 
 ## Preventing Credential Leaks
 

--- a/project-planning/sage-viz.md
+++ b/project-planning/sage-viz.md
@@ -392,7 +392,7 @@ def get_google_ads_client():
 # Initialize the database manager for accessing cached data
 db_manager = DatabaseManager(db_path=os.environ.get("GOOGLE_ADS_DB_PATH", "cache.db"))
 
-server = Server("google-mcp-server")
+server = Server("google-ads-mcp-server")
 
 @server.list_resources()
 async def handle_list_resources() -> list[types.Resource]:
@@ -983,7 +983,7 @@ async def main():
             read_stream,
             write_stream,
             InitializationOptions(
-                server_name="google-mcp-server",
+                server_name="google-ads-mcp-server",
                 server_version="0.1",
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(),


### PR DESCRIPTION
## Summary
- remove obsolete `google-mcp-server` paths
- clarify credential rotation instructions
- reference new server name in planning docs

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails to import modules)*

------
https://chatgpt.com/codex/tasks/task_e_6841d6f1ccec832f8931c0866a88b7b3