### PR TITLE
Fix missing token utility module

### DIFF
--- a/google_ads_mcp_server/utils/__init__.py
+++ b/google_ads_mcp_server/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for google_ads_mcp_server."""
+
+from .token_utils import generate_token, hash_token, verify_token

--- a/google_ads_mcp_server/utils/token_utils.py
+++ b/google_ads_mcp_server/utils/token_utils.py
@@ -1,0 +1,23 @@
+import secrets
+import hashlib
+import hmac
+
+
+def generate_token(length: int = 32) -> str:
+    """Generate a secure random token string."""
+    return secrets.token_urlsafe(length)
+
+
+def hash_token(token: str) -> str:
+    """Return the SHA-256 hash of the provided token."""
+    if token is None:
+        raise ValueError("token must not be None")
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def verify_token(stored_hash: str, provided_token: str) -> bool:
+    """Check whether the hash of the provided token matches the stored hash."""
+    if stored_hash is None or provided_token is None:
+        return False
+    provided_hash = hash_token(provided_token)
+    return hmac.compare_digest(stored_hash, provided_hash)


### PR DESCRIPTION
## Summary
- add missing `token_utils` with helpers for generating and verifying tokens
- expose new utilities via `utils/__init__.py`

## Testing
- `python - <<'EOF'
import google_ads_mcp_server.utils.token_utils as t
print('token', t.generate_token()[:5])
print('hash', t.hash_token('abc'))
print('verify', t.verify_token(t.hash_token('secret'), 'secret'))
EOF`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d48ab270832fa290d8c00dae6e79