### PR TITLE
Pin OpenTelemetry dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Follow these steps to run the MCP server using a local Python virtual environmen
    ```bash
    pip install -r requirements.txt
    ```
+   OpenTelemetry dependencies are pinned to version 1.21.0 to avoid
+   resolver backtracking errors during installation.
 
 4. **Configure Google Ads credentials**
    - Go to the [Google Ads API Console](https://developers.google.com/google-ads/api/docs/first-call/oauth-cloud) and create OAuth2 credentials.

--- a/google_ads_mcp_server/requirements.txt
+++ b/google_ads_mcp_server/requirements.txt
@@ -29,9 +29,9 @@ pytest-asyncio>=0.21.1
 pytest-cov>=4.1.0
 
 # Monitoring and Observability
-opentelemetry-api>=1.21.0
-opentelemetry-sdk>=1.21.0
-opentelemetry-exporter-prometheus>=1.21.0
+opentelemetry-api==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-exporter-prometheus==1.21.0
 opentelemetry-instrumentation-fastapi>=0.42b0
 opentelemetry-instrumentation-httpx>=0.42b0
 prometheus-client>=0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,9 @@ pytest>=7.4.0
 pytest-asyncio>=0.21.1
 
 # Monitoring and Observability
-opentelemetry-api>=1.21.0
-opentelemetry-sdk>=1.21.0
-opentelemetry-exporter-otlp>=1.21.0
+opentelemetry-api==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-exporter-otlp==1.21.0
 opentelemetry-instrumentation-fastapi>=0.42b0
 opentelemetry-instrumentation-httpx>=0.42b0
 prometheus-client>=0.17.1


### PR DESCRIPTION
## Summary
- pin OpenTelemetry packages to 1.21.0 to avoid dependency resolver backtracking
- document pinned versions in setup instructions

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google_ads_mcp_server')*

------
https://chatgpt.com/codex/tasks/task_e_6843198b2a34832f861dba6893595f68