### PR TITLE
Fix module import path

### DIFF
--- a/google_ads_mcp_server/README.md
+++ b/google_ads_mcp_server/README.md
@@ -60,7 +60,7 @@ google_ads_mcp_server/
 ### Running the Server
 
 ```
-python main.py
+python -m google_ads_mcp_server.main
 ```
 
 This will start the server on the default port 8000. The MCP endpoint will be available at `/mcp`.

--- a/google_ads_mcp_server/main.py
+++ b/google_ads_mcp_server/main.py
@@ -5,12 +5,11 @@ Google Ads MCP Server - Main Entry Point
 This module serves as the entry point for the Google Ads MCP Server application.
 """
 
-import os
 import logging
-from config import config
-from server import create_server
-from health import setup_health_checks
-from mcp.handlers import register_mcp_handlers
+from .config import config
+from .server import create_server
+from .health import setup_health_checks
+from .mcp.handlers import register_mcp_handlers
 import uvicorn
 
 # Import logging utilities


### PR DESCRIPTION
## Summary
- fix main module imports so package execution works
- document running with `python -m google_ads_mcp_server.main`

## Testing
- `ruff check google_ads_mcp_server/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google_ads_mcp_server')*
- `python -m google_ads_mcp_server.main --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68432807d4c4832f97a96fef33a87df8