### PR TITLE
Fix google module missing error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,10 @@ setup(
             "visualization.*",
         ]
     ),
-    # Add other dependencies here if needed for the package itself
-    # install_requires=[],
+    # Core runtime dependencies
+    install_requires=[
+        "google-ads>=21.3.0",
+    ],
     # Tests require additional packages, but they aren't needed for the package itself
     extras_require={
         "test": ["pytest", "unittest.mock"],


### PR DESCRIPTION
## Summary
- make google-ads a runtime dependency so the namespace package is available

## Testing
- `pre-commit run --files setup.py`
- `pytest -q` *(fails: AttributeError: 'InsightsService' object has no attribute 'get_performance_metrics')*

------
https://chatgpt.com/codex/tasks/task_e_684702209e40832fafeccfb6433d3801