### PR TITLE
Fix APP_ENV loading order

### DIFF
--- a/google_ads_mcp_server/config.py
+++ b/google_ads_mcp_server/config.py
@@ -12,6 +12,14 @@ import logging
 from enum import Enum
 from typing import Dict, Any, Optional
 
+from dotenv import load_dotenv, find_dotenv
+
+# Load environment variables early so APP_ENV is available when the
+# configuration instance is created. find_dotenv searches parent
+# directories to locate the .env file regardless of the current
+# working directory.
+load_dotenv(find_dotenv())
+
 logger = logging.getLogger("config-manager")
 
 class Environment(Enum):


### PR DESCRIPTION
## Summary
- load `.env` before creating Config

## Testing
- `flake8`
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684716419524832f86ecf1e1751e33b4