### PR TITLE
Fix database manager init in auth dependency

### DIFF
--- a/google_ads_mcp_server/auth/dependencies.py
+++ b/google_ads_mcp_server/auth/dependencies.py
@@ -6,13 +6,17 @@ from google_ads_mcp_server.db.factory import get_database_manager
 
 security = HTTPBearer()
 
-db_manager = get_database_manager()
+db_manager = None
 
 
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ):
     """FastAPI dependency to authenticate a request using a bearer token."""
+    global db_manager
+    if db_manager is None:
+        db_manager = get_database_manager()
+
     token = credentials.credentials
     token_hash = hash_token(token)
 


### PR DESCRIPTION
## Summary
- fix database type validation
- import working SQLite manager
- instantiate DB manager lazily in auth dependencies

## Testing
- `pre-commit run --files google_ads_mcp_server/auth/dependencies.py google_ads_mcp_server/db/factory.py`
- `pytest -q google_ads_mcp_server/auth/dependencies.py::get_current_user -vv`

------
https://chatgpt.com/codex/tasks/task_e_6848301ac510832fa01c7c6cc31c4378